### PR TITLE
Fix game tile URL

### DIFF
--- a/src/components/GameTiles/GameTile.tsx
+++ b/src/components/GameTiles/GameTile.tsx
@@ -6,7 +6,7 @@ interface Props {
 
 export const GameTile = ({ tile }: Props) => {
   return (
-    <a href={tile.smartlink}>
+    <a href={tile.gameUrl} target="_blank" rel="noreferrer">
       <img
         alt={tile.name}
         src={tile.image}

--- a/src/components/GameTiles/GameTilesPreview.tsx
+++ b/src/components/GameTiles/GameTilesPreview.tsx
@@ -32,7 +32,7 @@ export const GameTilesPreview = ({ tiles }: Props) => {
         css={{ '& > a': { flexShrink: 0 } }}
       >
         {tiles.map(tile => (
-          <GameTile tile={tile} />
+          <GameTile key={tile.id} tile={tile} />
         ))}
       </Stack>
     </Stack>

--- a/src/features/games/utils.ts
+++ b/src/features/games/utils.ts
@@ -13,7 +13,7 @@ import { Brand, BrandSlug, isBrandSlug, isState, State } from '../../app/types'
 export function getCasinoBaseUrl(
   brandSlug = 'betmgm',
   state = 'nj',
-  { gameSubdomain = false } = {},
+  { gameSubdomain = false, promoSubdomain = false } = {},
 ) {
   if (!isBrandSlug(brandSlug) || !isState(state)) {
     throw new Error('Invalid brand or state arguments')
@@ -21,7 +21,11 @@ export function getCasinoBaseUrl(
 
   const brand = Brand[BrandSlug[brandSlug]]
   const segments = {
-    product: gameSubdomain ? 'casinogames' : 'casino',
+    product: promoSubdomain
+      ? 'promo'
+      : gameSubdomain
+        ? 'casinogames'
+        : 'casino',
     state: state as State | null,
     brand,
     tld: 'com',

--- a/src/features/tiles/tilesSlice.test.ts
+++ b/src/features/tiles/tilesSlice.test.ts
@@ -16,6 +16,7 @@ const gameTile: ITile = {
   slug: 'test',
   smartlink: 'test',
   provider: 'test',
+  gameUrl: 'test',
 }
 
 interface LocalTestContext {

--- a/src/features/tiles/tilesSlice.ts
+++ b/src/features/tiles/tilesSlice.ts
@@ -11,6 +11,7 @@ export interface ITile {
   smartlink: string
   image: string
   provider: string
+  gameUrl: string
 }
 
 function gameToTile(game: [Game, Game?], brand = '', state = ''): ITile {
@@ -20,8 +21,11 @@ function gameToTile(game: [Game, Game?], brand = '', state = ''): ITile {
   const smartlink = game[1]
     ? `!!M2.Promo/launchmgc?gd=${slug}&gm=${mobile}`
     : `!!M2.CasinoHome/launchng/${slug}`
+  const gameUrl = game[1]
+    ? `${getCasinoBaseUrl(brand, state, { promoSubdomain: true })}/en/promo/launchmgc?gd=${slug}&gm=${mobile}`
+    : `${getCasinoBaseUrl(brand, state)}/en/games/launchng/${slug}`
 
-  return { id, name, provider, slug, mobile, smartlink, image }
+  return { id, name, provider, slug, mobile, smartlink, image, gameUrl }
 }
 
 export interface TilesSliceState {


### PR DESCRIPTION
The static game URL is now saved when adding game tiles so it can be used as the `href` value for the GameTile component. The tiles open in a new tab to avoid losing progress while assembling the game tiles.